### PR TITLE
fix: encoding of secret_key for DEV_MODE

### DIFF
--- a/kgea/config/__init__.py
+++ b/kgea/config/__init__.py
@@ -90,8 +90,7 @@ def _load_app_config() -> dict:
                 from cryptography import fernet
 
                 fernet_key = fernet.Fernet.generate_key()
-                secret_key = base64.urlsafe_b64decode(fernet_key)
-                config['secret_key'] = str(secret_key)
+                config['secret_key'] = fernet_key.decode("utf-8")
 
                 # persist updated updated config back to config.yaml?
                 with open(CONFIG_FILE_PATH, mode='w', encoding='utf-8') as app_config_file:

--- a/kgea/server/web_services/kgea_session.py
+++ b/kgea/server/web_services/kgea_session.py
@@ -56,7 +56,8 @@ class KgeaSession:
         if DEV_MODE:
             from aiohttp_session.cookie_storage import EncryptedCookieStorage
             # TODO: this needs to be global across the UI and Archive code bases(?!?)
-            secret_key = app_config['secret_key']
+            import base64
+            secret_key = base64.urlsafe_b64decode(str.encode(app_config['secret_key'],"utf-8"))
             cls._session_storage = EncryptedCookieStorage(secret_key)
         else:
             import aiomcache


### PR DESCRIPTION
fixes:

      env AWS_DEFAULT_PROFILE=uabpmi_jeff DEV_MODE=1 venv/bin/python -m kgea.server.web_ui
      RDFLib Version: 5.0.0
      WARNING:root:Missing aws 'host_account', 'guest_external_id' and/or 'iam_role_name' attributes in the '~/kgea/config/config.yaml' configuration file. Assume that you are running within an EC2 instance (configured with a suitable instance profile role).
      INFO:kgea.aws.assume_role:AssumeRole(): assume default credentials
      ERROR:kgea.server.web_services.catalog:get_github_releases(): need a non-null gh_token to access Github!
      Traceback (most recent call last):
        File "/home/jeff/srchome/pmi/src/kge/Knowledge_Graph_Exchange_Registry/kgea/server/web_services/kgea_session.py", line 71, in get_storage
          cls._session_storage
      AttributeError: type object 'KgeaSession' has no attribute '_session_storage'
      ​
      During handling of the above exception, another exception occurred:
      ​
      Traceback (most recent call last):
        File "/home/jeff/.pyenv/versions/3.7.9/lib/python3.7/runpy.py", line 193, in _run_module_as_main
          "__main__", mod_spec)
        File "/home/jeff/.pyenv/versions/3.7.9/lib/python3.7/runpy.py", line 85, in _run_code
          exec(code, run_globals)
        File "/home/jeff/srchome/pmi/src/kge/Knowledge_Graph_Exchange_Registry/kgea/server/web_ui/__main__.py", line 6, in <module>
          main()
        File "/home/jeff/srchome/pmi/src/kge/Knowledge_Graph_Exchange_Registry/kgea/server/web_ui/__init__.py", line 66, in main
          web.run_app(make_app(), port=8090)
        File "/home/jeff/srchome/pmi/src/kge/Knowledge_Graph_Exchange_Registry/venv/lib/python3.7/site-packages/aiohttp/web.py", line 433, in run_app
          reuse_port=reuse_port))
        File "/home/jeff/.pyenv/versions/3.7.9/lib/python3.7/asyncio/base_events.py", line 587, in run_until_complete
          return future.result()
        File "/home/jeff/srchome/pmi/src/kge/Knowledge_Graph_Exchange_Registry/venv/lib/python3.7/site-packages/aiohttp/web.py", line 296, in _run_app
          app = await app  # type: ignore
        File "/home/jeff/srchome/pmi/src/kge/Knowledge_Graph_Exchange_Registry/kgea/server/web_ui/__init__.py", line 52, in make_app
          KgeaSession.initialize(app)
        File "/home/jeff/srchome/pmi/src/kge/Knowledge_Graph_Exchange_Registry/kgea/server/web_services/kgea_session.py", line 45, in initialize
          storage = cls.get_storage()
        File "/home/jeff/srchome/pmi/src/kge/Knowledge_Graph_Exchange_Registry/kgea/server/web_services/kgea_session.py", line 76, in get_storage
          cls._initialize_storage()
        File "/home/jeff/srchome/pmi/src/kge/Knowledge_Graph_Exchange_Registry/kgea/server/web_services/kgea_session.py", line 60, in _initialize_storage
          cls._session_storage = EncryptedCookieStorage(secret_key)
        File "/home/jeff/srchome/pmi/src/kge/Knowledge_Graph_Exchange_Registry/venv/lib/python3.7/site-packages/aiohttp_session/cookie_storage.py", line 28, in __init__
          self._fernet = fernet.Fernet(secret_key)
        File "/home/jeff/srchome/pmi/src/kge/Knowledge_Graph_Exchange_Registry/venv/lib/python3.7/site-packages/cryptography/fernet.py", line 35, in __init__
          "Fernet key must be 32 url-safe base64-encoded bytes."
      ValueError: Fernet key must be 32 url-safe base64-encoded bytes.