### PR TITLE
configure backend request logging.

### DIFF
--- a/kgea/server/web_services/__init__.py
+++ b/kgea/server/web_services/__init__.py
@@ -6,6 +6,27 @@ from kgea.server.web_services.catalog import KgeArchiveCatalog
 from kgea.server.web_services.controllers.content_controller import download_file_set
 from kgea.server.web_services.kgea_session import KgeaSession
 
+import logging
+from logging.config import dictConfig
+dictConfig({
+    'version': 1,
+    'formatters': {'default': {
+        'format': '[%(asctime)s] %(levelname)s in %(module)s: %(message)s',
+    }},
+    'handlers': {
+        'tostdout': {
+            'class': 'logging.StreamHandler',
+            'stream': 'ext://sys.stdout',
+            'formatter': 'default'
+        }
+    },
+    'root': {
+        'level': 'DEBUG',
+        'handlers': ['tostdout']
+    }
+})
+connexion.apps.aiohttp_app.logger=logging.getLogger(__name__)
+
 
 def main():
     options = {
@@ -73,6 +94,10 @@ def main():
 
     KgeaSession.initialize(app.app)
 
-    app.run(port=8080)
+    app.run(
+        port=8080,
+        server="aiohttp",
+        use_default_access_log=True
+    )
 
     KgeaSession.close_global_session()


### PR DESCRIPTION
Looks like this:

  [2021-09-08 14:09:33,302] INFO in web_log: 127.0.0.1 [08/Sep/2021:21:09:32 +0000] "POST /archive/register/fileset HTTP/1.1" 302 775 "http://localhost:8090/" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.0 Safari/537.36"